### PR TITLE
No singleton

### DIFF
--- a/mm-video/qdsp6/venc/omx/inc/OMX_Venc.h
+++ b/mm-video/qdsp6/venc/omx/inc/OMX_Venc.h
@@ -68,7 +68,6 @@ class Venc : public qc_omx_component
     /**********************************************************************//**
      * @brief Class constructor
      *************************************************************************/
-    static Venc* get_instance();
     Venc();
 
     /**********************************************************************//**
@@ -192,8 +191,6 @@ class Venc : public qc_omx_component
         OMX_IN OMX_U32 nIndex);
 
   private:
-    static Venc* g_pVencInstance;
-
     /// Max number of input buffers (assumed)
     static const OMX_S32 MAX_IN_BUFFERS = 16;
 

--- a/mm-video/qdsp6/venc/omx/src/OMX_Venc.cpp
+++ b/mm-video/qdsp6/venc/omx/src/OMX_Venc.cpp
@@ -124,7 +124,7 @@ Venc* Venc::g_pVencInstance = NULL;
 extern "C" {
    void* get_omx_component_factory_fn(void)
    {
-     return Venc::get_instance();
+     return new Venc();
    }
 }
 #define GetLastError() 1

--- a/mm-video/qdsp6/venc/omx/src/OMX_Venc.cpp
+++ b/mm-video/qdsp6/venc/omx/src/OMX_Venc.cpp
@@ -85,8 +85,6 @@ static const char pRoleAVC[] = "video_encoder.avc";
 /*----------------------------------------------------------------------------
 * Static Variable Definitions
 * -------------------------------------------------------------------------*/
-Venc* Venc::g_pVencInstance = NULL;
-
 #define VEN_QCIF_DX                 176
 #define VEN_QCIF_DY                 144
 
@@ -170,7 +168,6 @@ Venc::Venc() :
 
 Venc::~Venc()
 {
-  g_pVencInstance = NULL;
   QC_OMX_MSG_HIGH("deconstructor (closing driver)");
   sem_destroy(&m_cmd_lock);
   ven_device_close(m_pDevice);
@@ -575,18 +572,6 @@ bail:
     free(m_pComponentName);
   }
   return result;
-}
-
-Venc* Venc::get_instance()
-{
-  QC_OMX_MSG_HIGH("getting instance...");
-  if (g_pVencInstance)
-  {
-    QC_OMX_MSG_ERROR("Singleton Class can't created more than one instance");
-    return NULL;
-  }
-  g_pVencInstance = new Venc();
-  return g_pVencInstance;
 }
 
 OMX_ERRORTYPE Venc::get_component_version(OMX_IN  OMX_HANDLETYPE hComponent,


### PR DESCRIPTION
This patchset makes it possible to instantiate two video encoders at a time (which in itself works just fine, while the OMX component still tries to block the caller from doing it). I'll try to get the same changes upstream, too. The second commit can be left out if you want to keep the changes small, to ease further merging with upstream.
