### PR TITLE
Revert "mm-video: vidc: venc: add set ctrl to request sequence header"

### DIFF
--- a/mm-video-v4l2/vidc/venc/src/video_encoder_device_v4l2.cpp
+++ b/mm-video-v4l2/vidc/venc/src/video_encoder_device_v4l2.cpp
@@ -1550,9 +1550,7 @@ unsigned venc_dev::venc_start(void)
 {
     enum v4l2_buf_type buf_type;
     int ret,r;
-    struct v4l2_control control = {0};
-
-    DEBUG_PRINT_HIGH("%s(): Check Profile/Level set in driver before start",
+    DEBUG_PRINT_HIGH("\n %s(): Check Profile/Level set in driver before start",
             __func__);
 
     if (!venc_set_profile_level(0, 0)) {
@@ -1588,15 +1586,6 @@ unsigned venc_dev::venc_start(void)
         return 1;
 
     streaming[CAPTURE_PORT] = true;
-
-    control.id = V4L2_CID_MPEG_VIDC_VIDEO_REQUEST_SEQ_HEADER;
-    control.value = 1;
-    ret = ioctl(m_nDriver_fd, VIDIOC_S_CTRL, &control);
-    if (ret) {
-        DEBUG_PRINT_ERROR("failed to request seq header");
-        return 1;
-    }
-
     stopped = 0;
     return 0;
 }


### PR DESCRIPTION
This reverts commit cf8408186605323a6797e5f431192ab434e79fff.

Build fails with a not declared in scope error. Reverting fixes this commit.
